### PR TITLE
fix: set chart axis position and hide line for scatterchart and bubblechart

### DIFF
--- a/src/PhpSpreadsheet/Chart/AxisPositionXml.php
+++ b/src/PhpSpreadsheet/Chart/AxisPositionXml.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace PhpOffice\PhpSpreadsheet\Chart;
+
+// https://learn.microsoft.com/en-us/dotnet/api/documentformat.openxml.drawing.charts.axispositionvalues?view=openxml-2.8.1
+abstract class AxisPositionXml
+{
+    public const BOTTOM = 'b';
+    public const LEFT = 'l';
+    public const RIGHT = 'r';
+    public const TOP = 't';
+}


### PR DESCRIPTION
We needed to recreate a patch, to be used by the trilations/DataVisualisation package

Also, see: https://github.com/samverhoeven/PhpSpreadsheet/commit/319e43e91d65ba50eaafbbf16c66ba5b50bdd82f

Relates: TAPP-5540

This is:

```
- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests
```

The existing tests do fail (but we'll need to test this manually in T-App anyway):

```
There were 9 failures:

1) PhpOffice\PhpSpreadsheetTests\Chart\Charts32CatAxValAxTest::test1CatAx1ValAx with data set #1 (false)
Failed asserting that 0 is identical to 1.

2) PhpOffice\PhpSpreadsheetTests\Chart\Charts32CatAxValAxTest::test1CatAx1ValAx with data set #2 (null)
Failed asserting that 0 is identical to 1.

3) PhpOffice\PhpSpreadsheetTests\Chart\Charts32ScatterTest::testScatter1
Failed asserting that null is identical to 2.25.

4) PhpOffice\PhpSpreadsheetTests\Chart\Charts32ScatterTest::testScatter6
Failed asserting that null is identical to 2.25.

5) PhpOffice\PhpSpreadsheetTests\Chart\Charts32ScatterTest::testScatter3
Failed asserting that false is true.

6) PhpOffice\PhpSpreadsheetTests\Chart\Charts32ScatterTest::testScatter7
Failed asserting that null is identical to 2.25.

7) PhpOffice\PhpSpreadsheetTests\Chart\Charts32ScatterTest::testScatter8
Failed asserting that null is identical to 2.5.

8) PhpOffice\PhpSpreadsheetTests\Chart\Charts32XmlTest::testCatAxValAx with data set #1 (false)
Failed asserting that 0 is identical to 1.

9) PhpOffice\PhpSpreadsheetTests\Chart\Charts32XmlTest::testCatAxValAx with data set #2 (null)
Failed asserting that 0 is identical to 1.

FAILURES!
Tests: 12690, Assertions: 19868, Failures: 9, Skipped: 11, Incomplete: 4.
```